### PR TITLE
Slighty modify reservation and inventory routes

### DIFF
--- a/src/routes/inventory.py
+++ b/src/routes/inventory.py
@@ -50,12 +50,12 @@ def get_all(**kwargs):
             row["moveable"] = bool(row["moveable"])
             row["main"] = bool(row["main"])
 
-            response.append(row)
-
         for row in main_items:
             row["children"] = [
                 child for child in child_items if child["item"] == row["item"]
             ]
+
+            response.append(row)
 
         return jsonify(response)
 


### PR DESCRIPTION
This PR changes the `reservation` to append the full properties of the item, admin, and user fields in the response instead of just the ID of each field. This also changes the `/inventory/` route to only include main items in the response. Children are then included in each main item (this is mostly just to help the front-end display the data easier).