### PR TITLE
Fixes item quantity bug

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   mysql-server:
-    image: mysql:8.0.19
+    image: mysql:latest
     restart: always
     environment:
       MYSQL_ROOT_PASSWORD: secret
@@ -10,7 +10,7 @@ services:
       - "3306:3306"
    
   phpmyadmin:
-    image: phpmyadmin/phpmyadmin:5.0.1
+    image: phpmyadmin/phpmyadmin:latest
     restart: always
     environment:
       PMA_HOST: mysql-server

--- a/src/routes/inventory.py
+++ b/src/routes/inventory.py
@@ -708,13 +708,23 @@ def update_item(item_id, **kwargs):
                 (location, item_id),
             )
 
+        # Quantity is a special case. If the quantity is 0, the item's status should
+        # be marked as unavailable. If the quantity is > 0, the item's status should
+        # be marked as available
         if quantity is not None:
+            values = {
+                "quantity": quantity,
+                "item_id": item_id,
+                "available": 0 if quantity == 0 else 1,
+            }
+
             cursor.execute(
                 """
-                UPDATE item SET quantity = %s
-                WHERE ID = (SELECT item from itemChild WHERE ID = %s)
+                UPDATE item
+                SET quantity = %(quantity)s, available = %(available)s
+                WHERE ID = (SELECT item from itemChild WHERE ID = %(item_id)s)
                 """,
-                (quantity, item_id),
+                values,
             )
 
         connection.commit()


### PR DESCRIPTION
When checking out an item, the quantity field for that item will be decremented by one. If the new quantity is 0, the item will be marked as unavailable. Once that item is returned, the quantity field for that item will be incremented by one. If the item was previously unavailable, it will be marked as available once again.

This PR also fixes another small issue: if the quantity of an item is updated to 0, that item will be marked as unavailable automatically. If the quantity of an item is updated from 0 to a number greater than 0, that item will be marked as available again.